### PR TITLE
west.yml: add missing qcbor to allow list

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,7 @@ manifest:
           - mcuboot
           - net-tools
           - nrfxlib
+          - qcbor
           - segger
           - tfm-mcuboot
           - tinycrypt


### PR DESCRIPTION
qcbor is no longer used by the Golioth SDK, but is still needed by some NCS libraries and should be included in the module allow list.