### PR TITLE
app_sensors: use zbus to publish and read weather sensor data

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -31,6 +31,7 @@ CONFIG_MAIN_STACK_SIZE=2048
 CONFIG_NET_LOG=y
 CONFIG_NET_SHELL=y
 CONFIG_REBOOT=y
+CONFIG_ZBUS=y
 
 # Flash memory (etc.) for firmware upgrade
 CONFIG_FLASH=y


### PR DESCRIPTION
Remove the need to use a mutex and global struct to store weather sensor readings. The weather sensor thread now publishes to ZBUS and the latest value may be read from ZBUS when needed.